### PR TITLE
fix crash when loading native ads with Mopub, fix auto clicked native ads

### DIFF
--- a/MoPub/iOS/AppLovinNativeCustomEvent.m
+++ b/MoPub/iOS/AppLovinNativeCustomEvent.m
@@ -78,7 +78,6 @@ static NSString *const kALMoPubMediationErrorDomain = @"com.applovin.sdk.mediati
          [self.delegate nativeCustomEvent: self didLoadAd: nativeAd];
          
          [adapter willAttachToView: nil];
-         [adapter displayContentForURL: nil rootViewController: [UIApplication sharedApplication].keyWindow.rootViewController];
      }];
 }
 
@@ -111,6 +110,7 @@ static NSString *const kALMoPubMediationErrorDomain = @"com.applovin.sdk.mediati
 
 @implementation AppLovinNativeAdapter
 @synthesize defaultActionURL;
+@synthesize delegate;
 
 #pragma mark - Initialization
 


### PR DESCRIPTION
fix crash when loading native ads with Mopub, as delegate proprty is not synthesized. Remove call to displayContentForURL:rootViewController: in nativeAdService:didLoadAds: as it causes ads to automatically perform click events when loaded.